### PR TITLE
Fix `lsFiles` malfunction 🪛

### DIFF
--- a/src/utils/coreutils.ts
+++ b/src/utils/coreutils.ts
@@ -209,15 +209,15 @@ function lsFiles(dirpath: StringPath,
                 });
             } else {
                 // Filter the entries with several checks from options
-                entries!.filter(function (entry: string): boolean {
+                entries = entries!.filter(function (entry: string): boolean {
                     return opts.match!.test(entry) &&
                            !opts.exclude!.test(entry);
                 });
                 
                 // Trim the paths, if the baseName option is true
                 if (opts.baseName) {
-                    entries!.map(function (entry: string): void {
-                        path.basename(entry)
+                    entries = entries!.map(function (entry: string): string {
+                        return path.basename(entry)
                     });
                 }
                 


### PR DESCRIPTION
## Overview

Fixed the `lsFiles` function in `coreutils` module. All specified options will now changes the returned entries correctly.

All commits:

- 98d8dd7 - Fix malfunction of `lsFiles` function
