### PR TITLE
Add several new server options

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "scripts": {
         "start": "nodemon build/src/server/server.js",
         "start:dry": "node build/src/server/server.js --dry-run",
+        "start:help": "node build/src/server/server.js --?",
         "build": "npm run build:js && npm run build:css",
         "build:js": "tsc",
         "build:css": "node build/src/build.js sass",

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -13,7 +13,7 @@
  * # the default address: `http://localhost:4312`. Users can also customize
  * # the server settings by defining environment variables. For example:
  *
- * $ HOST="<your-ip-address>" PORT="<port>" npm start
+ * $ HOST="<host>" PORT="<port>" npm start
  *
  * @module      server/server
  * @requires    module:utils/coreutils.clientPaths
@@ -22,12 +22,13 @@
  * @requires    module:express
  * @author      Ryuu Mitsuki
  * @since       0.1.0
- * @version     0.2
+ * @version     0.3
  * @copyright   2023 CV. DR2E
  * @license     MIT
  */
 
 import * as express from 'express';
+import * as util from 'util';
 
 import { clientPaths, isObject } from '../utils/coreutils';
 import setup from '../setup';
@@ -77,9 +78,9 @@ const defaultAddress: ServerAddress = {
  *
  * @public
  * @function
- * @author  Ryuu Mitsuki
- * @since   0.1.0
- * @version 0.3
+ * @author   Ryuu Mitsuki
+ * @since    0.1.0
+ * @version  0.3
  */
 function run(opts?: ServerOptions): void {
     let address: ServerAddress;
@@ -122,6 +123,32 @@ function run(opts?: ServerOptions): void {
                 address.host}:${address.port}'\n`);
     });
 }
+
+/**
+ * Prints the help message to the console output then exit the program.
+ *
+ * @public
+ * @function
+ * @author   Ryuu Mitsuki
+ * @since    0.2.0
+ * @version  1.0
+ */
+function printHelp(exit: boolean = true): void {
+    console.log(`
+Usage:
+   $ npm start [-- [options]]
+   $ node path/to/server.js [options]
+
+Options:
+   -n, --dry-run\t\tRun the setup, but not the server.
+   --no-setup, --skip-setup\tSkip the setup then run the server.
+   ?, --?\t\t\tPrint this help message.
+`
+    );
+    
+    if (exit) process.exit();
+}
+
 
 // Run as main module
 if (require.main === module) {


### PR DESCRIPTION
## Overview

This pull request brings new server options that could help and useful in development.

Added a new function to print the help message to the console output.

https://github.com/mitsuki31/SkiArticle/blob/4b99e484be04783a359e5af237db750545c9dafc/src/server/server.ts#L136

We also added a new `npm` script to package.json file called `start:help`
> Needs sub-command `run` before executing on it.

There is two methods to show the help message.

1. `npm run start:help`&nbsp; (without `nodemon`)
2. `npm start -- [--?|?]`&nbsp; (use `nodemon`)

> If you're using the second method, which use the `nodemon`, you need to press <kbd>Ctrl-C</kbd> to exit from `nodemon` itself.

Expected output:

```
Usage:
   $ npm start [-- [options]]
   $ node path/to/server.js [options]                                  
Options:
   -n, --dry-run                Run the setup, but not the server.
   --no-setup, --skip-setup     Skip the setup then run the server.
   ?, --?                       Print this help message.
```

<details>
<summary>All commits</summary>

- 4b99e48 - Add new script to display the server help message
- 6255bce - Refactor the driver code of server module
- 7542362 - Introduce a new function that print help message

</details>
