### PR TITLE
Dynamically update the copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 CV. DR2E
+Copyright (c) 2023-2024 CV. DR2E
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -8,7 +8,7 @@
  * @author    Nuryadani
  * @since     0.1.0
  * @version   0.1.0
- * @copyright 2023 CV. DR2E
+ * @copyright 2023-2024 CV. DR2E
  * @license   MIT
  */
 

--- a/public/assets/js/setup.js
+++ b/public/assets/js/setup.js
@@ -106,29 +106,47 @@ document.addEventListener("DOMContentLoaded", async () => {
 });
 
 /**
-* Updates copyright year elements within the DOM upon page load.
-*
-*  - Maintains current copyright year without manual modifications.
-*  - Enhances user experience with up-to-date information.
-*
-* Executes only once using `{ once: true }` configuration.
-*
-* @summary Dynamically ensures accurate copyright year display.
-*
-* @name    copyrightYearInjector
-* @author  Ryuu Mitsuki
-* @since   0.3.0
-* @version 1.0
-*/
+ * Dynamically updates the copyright year elements within the DOM upon the completion
+ * of the initial HTML document parsing. This ensures that the displayed copyright year
+ * is always accurate and up-to-date without requiring manual interventions.
+ * 
+ * This function is designed to enhance the user experience by providing a seamless
+ * mechanism for reflecting the latest copyright information.
+ *
+ * @summary Ensures accurate and dynamic display of the copyright year on
+ * specified elements.
+ *
+ * @description
+ * This script listens for the `DOMContentLoaded` event, signaling that the initial
+ * HTML document parsing is complete and the DOM is fully loaded. Upon this event,
+ * it acquires all elements with the specified class name, typically used for
+ * displaying the copyright year (`copyright-year`).
+ *
+ * Using an efficient `for...of` loop, the function traverses the retrieved
+ * elements and injects the current year into their `innerHTML` property.
+ * This process ensures that users consistently see the correct copyright year
+ * without the need for manual updates in the source code.
+ *
+ * **Additional Note:**
+ * The function is configured to execute only once, utilizing the
+ * `{ once: true }` option, optimizing performance by preventing redundant executions.
+ *
+ * @function
+ * @name     copyrightYearInjector
+ * @author   Ryuu Mitsuki
+ * @since    0.3.0
+ * @version  1.0
+ */
 document.addEventListener("DOMContentLoaded", () => {
     // Acquire all elements that bearing the targeted class name
     const copyrightYearElements =
         document.getElementsByClassName("copyright-year");
+    const currentYear = new Date().getFullYear();
 
     // Traverses the retrieved elements using
-    // the `for...of` loop for efficient iteration.
+    // the `for...of` loop for efficient iteration
     for (const element of copyrightYearElements) {
         // Inject the current year into the `innerHTML` property
-        element.innerHTML = (new Date()).getFullYear();
+        element.innerHTML = currentYear;
     }
-}, { once: true });  // Single execution
+}, { once: true });  // Single execution, prevent redundant executions

--- a/public/assets/js/setup.js
+++ b/public/assets/js/setup.js
@@ -9,8 +9,8 @@
  * @author    Ryuu Mitsuki
  * @author    Nuryadani
  * @since     0.1.0
- * @version   0.1.0
- * @copyright 2023 CV. DR2E
+ * @version   0.2.0
+ * @copyright 2023-2024 CV. DR2E
  * @license   MIT
  */
 
@@ -36,7 +36,7 @@
  * @author   Ryuu Mitsuki
  * @author   Nuryadani
  * @since    0.1.0
- * @version  0.1.3-prototype
+ * @version  0.1.3
  */
 document.addEventListener("DOMContentLoaded", async () => {
     /**
@@ -104,3 +104,31 @@ document.addEventListener("DOMContentLoaded", async () => {
     // Remove the event listener after executed once
     once: true
 });
+
+/**
+* Updates copyright year elements within the DOM upon page load.
+*
+*  - Maintains current copyright year without manual modifications.
+*  - Enhances user experience with up-to-date information.
+*
+* Executes only once using `{ once: true }` configuration.
+*
+* @summary Dynamically ensures accurate copyright year display.
+*
+* @name    copyrightYearInjector
+* @author  Ryuu Mitsuki
+* @since   0.3.0
+* @version 1.0
+*/
+document.addEventListener("DOMContentLoaded", () => {
+    // Acquire all elements that bearing the targeted class name
+    const copyrightYearElements =
+        document.getElementsByClassName("copyright-year");
+
+    // Traverses the retrieved elements using
+    // the `for...of` loop for efficient iteration.
+    for (const element of copyrightYearElements) {
+        // Inject the current year into the `innerHTML` property
+        element.innerHTML = (new Date()).getFullYear();
+    }
+}, { once: true });  // Single execution

--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!--
- * Copyright (c) 2023 CV. DR2E
+ * Copyright (c) 2023-2024 CV. DR2E
  *
- * Version: 0.2.0, 19 December 2023
+ * Version: 0.2.1, 12 January 2024
  * Authors: Ryuu Mitsuki, Nuryadani
 -->
 
@@ -54,7 +54,7 @@
                             <li class="menu__repo"><a class="dr2e--github-repo" alt="GitHub Repo" target="_blank"><i class="bx bx-code-alt"></i>Kode Sumber</a></li>
                             <li class="menu__about"><a href="#"><i class="bx bx-info-circle"></i>Tentang</a></li>
                         </ul>
-                        <p class="copyright">&copy; 2023 CV. DR2E dan SMK Sukamandi.</p>
+                        <p class="copyright">&copy; <span class="copyright-year"></span> CV. DR2E dan SMK Sukamandi.</p>
                     </div>
                 </nav>
             </div>
@@ -203,7 +203,7 @@
                         <a class="logo dr2e--instagram" alt="Instagram SMK Sukamandi" target="_blank"><i class="bx bxl-instagram"></i></a>
                         <a class="logo dr2e--youtube" alt="YouTube SMK Sukamandi" target="_blank"><i class="bx bxl-youtube"></i></a>
                     </div>
-                    <p>&copy; 2023 CV. DR2E dan <a class="dr2e--instagram">SMK Sukamandi</a>. Seluruh hak cipta dilindungi undang-undang. Telah terakreditasi A dengan <a href="https://bansm.kemdikbud.go.id/home/detailsekolah/C712AD4F-CA8D-4D44-9810-12CFBC6CA462">No. SK 582/BAN-SM/SK/2023</a> yang dikeluarkan pada 28 April 2023.</p>
+                    <p>&copy; <span class="copyright-year"></span> CV. DR2E dan <a class="dr2e--instagram">SMK Sukamandi</a>. Seluruh hak cipta dilindungi undang-undang. Telah terakreditasi A dengan <a href="https://bansm.kemdikbud.go.id/home/detailsekolah/C712AD4F-CA8D-4D44-9810-12CFBC6CA462">No. SK 582/BAN-SM/SK/2023</a> yang dikeluarkan pada 28 April 2023.</p>
                 </div>
             </div>
         </footer>
@@ -212,6 +212,7 @@
         <div class="overlay"></div>
 
         <!--::::  JavaScript  ::::-->
+        <!-- DOM need to be completely loaded before these scripts -->
         <script type="text/javascript" src="assets/js/setup.js" charset="UTF-8"></script>
         <script type="text/javascript" src="assets/js/main.js" charset="UTF-8"></script>
     </body>

--- a/src/build.ts
+++ b/src/build.ts
@@ -13,7 +13,7 @@
  * @author    Ryuu Mitsuki
  * @since     0.1.0
  * @version   0.2
- * @copyright 2023 CV. DR2E
+ * @copyright 2023-2024 CV. DR2E
  * @license   MIT
  */
 

--- a/src/scss/_allstyles.scss
+++ b/src/scss/_allstyles.scss
@@ -1,6 +1,6 @@
 // Imports Base
 //
-// Copyright (c) 2023 CV. DR2E.
+// Copyright (c) 2023-2024 CV. DR2E.
 // Licensed under the MIT License.
 //
 

--- a/src/scss/base/_global.scss
+++ b/src/scss/base/_global.scss
@@ -3,7 +3,7 @@
 //
 // Written by Ryuu Mitsuki.
 //
-// Copyright (c) 2023 CV. DR2E.
+// Copyright (c) 2023-2024 CV. DR2E.
 // Licensed under the MIT License.
 //
 

--- a/src/scss/base/_mixin.scss
+++ b/src/scss/base/_mixin.scss
@@ -4,7 +4,7 @@
 //
 // Written by Ryuu Mitsuki.
 //
-// Copyright (c) 2023 CV. DR2E.
+// Copyright (c) 2023-2024 CV. DR2E.
 // Licensed under the MIT License.
 //
 

--- a/src/scss/base/_reset.scss
+++ b/src/scss/base/_reset.scss
@@ -5,7 +5,7 @@
 //
 // Written by Ryuu Mitsuki.
 //
-// Copyright (c) 2023 CV. DR2E.
+// Copyright (c) 2023-2024 CV. DR2E.
 // Licensed under the MIT License.
 //
 

--- a/src/scss/components/_main-base.scss
+++ b/src/scss/components/_main-base.scss
@@ -2,7 +2,7 @@
 //
 // Written by Ryuu Mitsuki.
 //
-// Copyright (c) 2023 CV. DR2E.
+// Copyright (c) 2023-2024 CV. DR2E.
 // Licensed under the MIT License.
 //
 

--- a/src/scss/components/_navbar-base.scss
+++ b/src/scss/components/_navbar-base.scss
@@ -4,7 +4,7 @@
 //
 // Written by Ryuu Mitsuki.
 //
-// Copyright (c) 2023 CV. DR2E.
+// Copyright (c) 2023-2024 CV. DR2E.
 // Licensed under the MIT License.
 //
 

--- a/src/scss/layouts/_footer.scss
+++ b/src/scss/layouts/_footer.scss
@@ -2,7 +2,7 @@
 //
 // Written by Ryuu Mitsuki
 //
-// Copyright (c) 2023 CV. DR2E.
+// Copyright (c) 2023-2024 CV. DR2E.
 // Licensed under the MIT License.
 //
 

--- a/src/scss/layouts/_header.scss
+++ b/src/scss/layouts/_header.scss
@@ -4,7 +4,7 @@
 //
 // Written by Ryuu Mitsuki.
 //
-// Copyright (c) 2023 CV. DR2E.
+// Copyright (c) 2023-2024 CV. DR2E.
 // Licensed under MIT License.
 //
 

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -2,7 +2,7 @@
 //
 // Written by Ryuu Mitsuki.
 //
-// Copyright (c) 2023 CV. DR2E.
+// Copyright (c) 2023-2024 CV. DR2E.
 // Licensed under MIT License.
 //
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -23,7 +23,7 @@
  * @author      Ryuu Mitsuki
  * @since       0.1.0
  * @version     0.3
- * @copyright   2023 CV. DR2E
+ * @copyright   2023-2024 CV. DR2E
  * @license     MIT
  */
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -9,7 +9,7 @@
  * @author    Ryuu Mitsuki
  * @since     0.1.0
  * @version   0.1
- * @copyright 2023 CV. DR2E
+ * @copyright 2023-2024 CV. DR2E
  * @license   MIT
  */
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,7 +6,7 @@
  * @author    Ryuu Mitsuki
  * @since     0.1.0
  * @version   0.2
- * @copyright 2023 CV. DR2E
+ * @copyright 2023-2024 CV. DR2E
  * @license   MIT
  */
 

--- a/src/utils/coreutils.ts
+++ b/src/utils/coreutils.ts
@@ -10,7 +10,7 @@
  * @author    Ryuu Mitsuki
  * @since     0.1.0
  * @version   0.2
- * @copyright 2023 CV. DR2E
+ * @copyright 2023-2024 CV. DR2E
  * @license   MIT
  */
 


### PR DESCRIPTION
## Overview

This pull request introduces the capability to automatically inject the current copyright year into designated elements, eliminating the need for manual updates. It also includes optimizations for performance and documentation clarity.

## Changes Made

- **Dynamic copyright year injection (a0eef53):**  
    https://github.com/mitsuki31/SkiArticle/blob/cebf9a7fbd6fb0847d21dddbbf5b69ce472166ec/public/assets/js/setup.js#L140-L152
    - Injects the current year, retrieved using the `Date` class, into elements with the class name `copyright-year`.
    - Ensures consistent and up-to-date copyright information without manual intervention.
- **Enhanced documentation (cebf9a7):**  
    - Improved documentation for the `copyrightYearInjector` function, providing clearer guidance on its usage and functionality.
- **Performance optimization (cebf9a7):**  
    - Stores the current year in a variable to avoid redundant function calls during iteration, enhancing performance.
- **Copyright year update (ed150d1):**  
    - Sets the copyright year to the current year, ensuring immediate accuracy upon implementation.

<details>
<summary>All commits</summary>

- cebf9a7 - docs: Improve the `copyrightYearInjector` docs
- ed150d1 - Update the copyright year
- a0eef53 - feat: Add capability to inject copyright year dynamically

</details>
